### PR TITLE
fix: Simplify resampling and adjust benchmarks in GEO suite.

### DIFF
--- a/benchmark/suites/inf/_suite.hblib
+++ b/benchmark/suites/inf/_suite.hblib
@@ -87,53 +87,8 @@
 
 ; Resampling
 
-(output fact ResamplingMethod
-  (.method Str))
-
-(computation nearest ResamplingMethod
-  () ())
-
-(computation bilinear ResamplingMethod
-  () ())
-
-(computation cubic ResamplingMethod
-  () ())
-
-(computation cubic_spline ResamplingMethod
-  () ())
-
-(computation lanczos ResamplingMethod
-  () ())
-
-(computation average ResamplingMethod
-  () ())
-
-(computation mode ResamplingMethod
-  () ())
-
-(computation gauss ResamplingMethod
-  () ())
-
-(computation max ResamplingMethod
-  () ())
-
-(computation min ResamplingMethod
-  () ())
-
-(computation med ResamplingMethod
-  () ())
-
-(computation q1 ResamplingMethod
-  () ())
-
-(computation q3 ResamplingMethod
-  () ())
-
-(computation sum ResamplingMethod
-  () ())
-
-(computation rms ResamplingMethod
-  () ())
+(input fact ResamplingMethod
+  (.val Str))
 
 (computation resample Raster
   ((raster Raster) (method ResamplingMethod) (res Resolution))

--- a/benchmark/suites/inf/geo_mosaic.hb
+++ b/benchmark/suites/inf/geo_mosaic.hb
@@ -1,4 +1,7 @@
 (facts
+  (CRS (.val "EPSG:32610"))
+  (CRS (.val "EPSG:32611"))
+
   (InputRaster
     (.name "Hillshade 1")
     (.data "hillshade-1.tif")

--- a/benchmark/suites/inf/geo_ndvi.hb
+++ b/benchmark/suites/inf/geo_ndvi.hb
@@ -3,6 +3,7 @@
   (Resolution (.val 90))
   (CRS (.val "EPSG:32610"))
   (CRS (.val "EPSG:26943"))
+  (ResamplingMethod (.val "bilinear"))
 
   (InputRaster
     (.name "Landsat Scene")


### PR DESCRIPTION
This PR simplifies how we model resampling in the GEO suite to act a bit more like `warp` / `reproject`. Rather than resampling methods being an enum of `computation`s, we just model them as `input fact`s supplied in the benchmark. This helps to simplify the `geo_ndvi` benchmark in the near term, although we could revisit this API for a longer-term effort at providing examples of how to do enum-style modeling in `honeybee`.

In addition, I adjusted the benchmark programs to support the new API and generate terminating derivation trees.