### PR TITLE
Remove `wasm-pack` to enable support on ARM Macs

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,5 +36,9 @@ toml = "0.8.19"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+opt-level = "z"
+lto = true
+
 [lints.clippy]
 new_without_default = "allow"

--- a/editor/Makefile
+++ b/editor/Makefile
@@ -36,8 +36,10 @@ endif
 
 $(OUT_DIR)/pkg/honeybee.js: $(wildcard ../backend/src/*.rs)
 	cd ../backend/ && \
-	cargo build && \
-	wasm-pack build --target web --out-dir ../$(HERE_DIR)/www/pkg
+	cargo build --lib --target wasm32-unknown-unknown --release && \
+	wasm-bindgen target/wasm32-unknown-unknown/release/honeybee.wasm \
+		--out-dir ../$(HERE_DIR)/www/pkg \
+		--target web
 
 $(OUT_DIR)/std-bio.hblib.toml: $(wildcard ../library-generator/*.py)
 	uv run \


### PR DESCRIPTION
`wasm-pack` has unfortunately been sunsetted it seems: https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/.

Additionally, it did not appear to support ARM Mac devices (which are becoming increasingly popular):

```
Error: Unsupported platform: Darwin arm64
    at getPlatform (/usr/local/lib/node_modules/wasm-pack/binary.js:20:9)
    at getBinary (/usr/local/lib/node_modules/wasm-pack/binary.js:24:20)
    at run (/usr/local/lib/node_modules/wasm-pack/binary.js:33:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/wasm-pack/run.js:4:1)
    at Module._compile (node:internal/modules/cjs/loader:1554:14)
    at Object..js (node:internal/modules/cjs/loader:1706:10)
    at Module.load (node:internal/modules/cjs/loader:1289:32)
    at Function._load (node:internal/modules/cjs/loader:1108:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
```

I looked into what `wasm-pack` was doing: https://fourteenscrews.com/essays/look-ma-no-wasm-pack/. And I also read up on what others have done to replace it: https://www.reddit.com/r/rust/comments/1m658j4/sunsetting_the_rustwasm_github_org/.

I edited `editor/Makefile` to directly call `cargo build` and `wasm-bindgen`. 

I also had to change the optimisation level to optimise for size:

```toml
opt-level = "z"
```

This was because of this error:

```
error: failed to build archive at `/Users/sam/Documents/GitHub/honeybee/backend/target/wasm32-unknown-unknown/release/deps/libpsm-7e8ce9d01055cea2.rlib`: LLVM error: section too large
```

I'm not sure if this is related to switching to this new setup.

Let me know if there are good places to add documentation for this. To get this to work on my computer I had to run:

```sh
rustup target add wasm32-unknown-unknown
cargo install -f wasm-bindgen-cli --version 0.2.100
```

