### PR TITLE
Update pyproject.toml and uv.lock to reflect new directory naming

### DIFF
--- a/libs/fuseflow/pyproject.toml
+++ b/libs/fuseflow/pyproject.toml
@@ -10,10 +10,10 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-honey-lang = { path = "../../honey_lang", editable = true }
+honey-lang = { path = "../../honey", editable = true }
 
 [tool.ty.environment]
-extra-paths = ["../../honey_lang"]
+extra-paths = ["../../honey"]
 
 [dependency-groups]
 dev = [

--- a/libs/fuseflow/uv.lock
+++ b/libs/fuseflow/uv.lock
@@ -55,7 +55,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "honey-lang", editable = "../../honey_lang" },
+    { name = "honey-lang", editable = "../../honey" },
     { name = "polars", specifier = ">=1.41.0" },
 ]
 
@@ -68,7 +68,7 @@ dev = [
 [[package]]
 name = "honey-lang"
 version = "0.7.0"
-source = { editable = "../../honey_lang" }
+source = { editable = "../../honey" }
 
 [[package]]
 name = "ipython"


### PR DESCRIPTION
Short PR to update the fuseflow library dependencies after `honey_lang` changed to `honey`. 